### PR TITLE
FIX replace in_array check with `hasTable` check.

### DIFF
--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -281,7 +281,8 @@ class Subsite extends DataObject
 
             /** @skipUpgrade */
             $domainTableName = $schema->tableName(SubsiteDomain::class);
-            if (!in_array($domainTableName, DB::table_list())) {
+            
+            if (!DB::get_schema()->hasTable($domainTableName)) {
                 // Table hasn't been created yet. Might be a dev/build, skip.
                 return 0;
             }


### PR DESCRIPTION
in_array is case-sensitive and may not detect that a table exists when using lowercase format